### PR TITLE
Support JS extension for components

### DIFF
--- a/src/reactview.js
+++ b/src/reactview.js
@@ -56,17 +56,20 @@ class ReactView{
       module: {
           loaders: [
               {
-                test: /\.jsx$/,
-                loader: 'react-hot'
+                test: /\.jsx?$/,
+                loader: 'react-hot',
+                exclude: /node_modules/
               },
               {
-                  test: /\.jsx$/,
-                  loader: 'babel-loader?stage=0'
+                  test: /\.jsx?$/,
+                  loader: 'babel-loader?stage=0',
+                  exclude: /node_modules/
               },
               {
-                  test: /\.jsx$/,
+                  test: /\.jsx?$/,
                   loader: 'render-placement-loader',
-                  query: { props: props, component: component || '' }
+                  query: { props: props, component: component || '' },
+                  exclude: /node_modules/
               },
               { 
                 test: /\.css$/,


### PR DESCRIPTION
Adding `node_modules` as an exclude because otherwise it tries to compile itself.
